### PR TITLE
Fix reconnect logic for websocket connection errors

### DIFF
--- a/evpp/TcpClient.h
+++ b/evpp/TcpClient.h
@@ -21,6 +21,7 @@ public:
         connect_timeout = HIO_DEFAULT_CONNECT_TIMEOUT;
         tls = false;
         tls_setting = NULL;
+        delegate_reconn_reset = false;
         reconn_setting = NULL;
         unpack_setting = NULL;
     }
@@ -128,12 +129,12 @@ public:
             if (unpack_setting) {
                 channel->setUnpack(unpack_setting);
             }
+            if (!delegate_reconn_reset && reconn_setting) {
+                reconn_setting_reset(reconn_setting);
+            }
             channel->startRead();
             if (onConnection) {
                 onConnection(channel);
-            }
-            if (reconn_setting) {
-                reconn_setting_reset(reconn_setting);
             }
         };
         channel->onread = [this](Buffer* buf) {
@@ -241,6 +242,7 @@ public:
     int                     connect_timeout;
     bool                    tls;
     hssl_ctx_opt_t*         tls_setting;
+    bool                    delegate_reconn_reset;
     reconn_setting_t*       reconn_setting;
     unpack_setting_t*       unpack_setting;
 

--- a/http/client/WebSocketClient.cpp
+++ b/http/client/WebSocketClient.cpp
@@ -13,6 +13,7 @@ WebSocketClient::WebSocketClient(EventLoopPtr loop)
     state = WS_CLOSED;
     ping_interval = DEFAULT_WS_PING_INTERVAL;
     ping_cnt = 0;
+    delegate_reconn_reset = true;
 }
 
 WebSocketClient::~WebSocketClient() {
@@ -180,6 +181,7 @@ int WebSocketClient::open(const char* _url, const http_headers& headers) {
                         channel->sendPing();
                     });
                 }
+                reconn_setting_reset(reconn_setting);
                 if (onopen) onopen();
             }
         }

--- a/http/client/WebSocketClient.cpp
+++ b/http/client/WebSocketClient.cpp
@@ -125,6 +125,13 @@ int WebSocketClient::open(const char* _url, const http_headers& headers) {
                             return;
                         }
                     }
+                    else if (http_resp_->status_code == HTTP_STATUS_FORBIDDEN) {
+                        hloge("upgrade to websocket rejected by server: status_code=%d", http_resp_->status_code);
+                        state = WS_REJECTED;
+                        setReconnect(NULL);
+                        channel->close();
+                        return;
+                    }
                     hloge("server side could not upgrade to websocket: status_code=%d", http_resp_->status_code);
                     channel->close();
                     return;

--- a/http/client/WebSocketClient.h
+++ b/http/client/WebSocketClient.h
@@ -35,28 +35,27 @@ public:
     int send(const char* buf, int len, enum ws_opcode opcode = WS_OPCODE_BINARY);
 
     // setConnectTimeout / setPingInterval / setReconnect
-    void setPingInterval(int ms) {
-        ping_interval = ms;
-    }
+    void setPingInterval(int ms) { ping_interval = ms; }
 
     // NOTE: call before open
-    void setHttpRequest(const HttpRequestPtr& req) {
-        http_req_ = req;
-    }
+    void setHttpRequest(const HttpRequestPtr& req) { http_req_ = req; }
 
     // NOTE: call when onopen
-    const HttpResponsePtr& getHttpResponse() {
-        return http_resp_;
-    }
+    const HttpResponsePtr& getHttpResponse() { return http_resp_; }
 
-private:
     enum State {
         CONNECTING,
         CONNECTED,
         WS_UPGRADING,
         WS_OPENED,
         WS_CLOSED,
-    } state;
+        WS_REJECTED,
+    };
+
+    State getState() { return state; }
+
+private:
+    State state;
     HttpParserPtr       http_parser_;
     HttpRequestPtr      http_req_;
     HttpResponsePtr     http_resp_;


### PR DESCRIPTION
### Description

This pull request fixes the reconnection logic for the WebSocket client. In case of issues in the protocol upgrade, now the WebSocket client follows the reconnection logic configured on the TcpClient.

Here is a screenshot that shows how the reconnections are done (check the exponential increase of time):
<img width="1013" alt="image" src="https://github.com/magicinternet/libhv/assets/5703274/97a7f3d4-e8be-4dec-99c7-3ca6929481c9">

For details about the issue: https://github.com/magicinternet/massivesdk/pull/1369#issuecomment-1924680625